### PR TITLE
Removed thesaurus development

### DIFF
--- a/README
+++ b/README
@@ -22,29 +22,3 @@ Relevant Directories:
 
    kde/
      Contains AiksaurusKDE interface library.
-
-
-Thesaurus Development
-=====================
-
-There is some good documentation available at the developer section
-of the web site:
-
-    http://www.aiksaurus.com/developers/
-     
-
-If you want to do work on the thesaurus data, i.e. add synonyms or 
-so forth, please visit 
-
-    http://www.aiksaurus.com/developers/datatools/
-
-The data tools are very large (~100MB!) so I've kept them out of CVS.
-
-
-Feel free to contact me with any questions!  I'd love to hear about 
-what you're working on.
-
-    Jared Davis
-    jared@aiksaurus.com
-   
-


### PR DESCRIPTION
aiksaurus.com is a cancer insurance web site, the information and URLs were only misleading.
